### PR TITLE
Techtree tweaks - Feedback needed

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1,4 +1,11 @@
 
+//Singulostation begin - Technology tweaks
+/*
+This file contains multiple changes to make technology more suited to SinguloStation Blue.
+Instead of sprinkling comments around the file, the changes are noted down here:
+
+*/
+
 //Current rate: 135000 research points in 90 minutes
 
 //Base Nodes

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -5,6 +5,10 @@ This file contains multiple changes to make technology more suited to SinguloSta
 Instead of sprinkling comments around the file, the changes are noted down here:
 
 - Ore Silo was moved from Applied Bluespace Research to Advanced Engineering
+- Basic Shuttle Technology has been moved up:
+ - Tech tier lowered from 3 to 1
+ - Dependencies removed - can be researched roundstart
+ - Cost halved from 10000 to 5000
 */
 
 //Current rate: 135000 research points in 90 minutes
@@ -333,12 +337,12 @@ Instead of sprinkling comments around the file, the changes are noted down here:
 /////////////////////////shuttle tech/////////////////////////
 /datum/techweb_node/basic_shuttle_tech
 	id = "basic_shuttle"
-	tech_tier = 3
+	tech_tier = 1
 	display_name = "Basic Shuttle Research"
 	description = "Research the technology required to create and use basic shuttles."
-	prereq_ids = list("bluespace_travel", "adv_engi")
+	prereq_ids = list("base")
 	design_ids = list("shuttle_creator", "engine_plasma", "engine_heater", "shuttle_control", "wingpack")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
 /datum/techweb_node/nullspacebreaching

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -9,6 +9,10 @@ Instead of sprinkling comments around the file, the changes are noted down here:
  - Tech tier lowered from 3 to 1
  - Dependencies removed - can be researched roundstart
  - Cost halved from 10000 to 5000
+- Plasma Refining has been moved up
+ - Tech tier lowered from 4 to 2
+ - Added dependency on basic_plasma
+ - No longer a hidden research
 */
 
 //Current rate: 135000 research points in 90 minutes
@@ -356,14 +360,13 @@ Instead of sprinkling comments around the file, the changes are noted down here:
 
 /datum/techweb_node/plasma_refiner
 	id = "plasmarefiner"
-	tech_tier = 4
+	tech_tier = 2
 	display_name = "Plasma Refining"
 	description = "Development of a machine capable of safely and efficently converting plasma from a solid state to a gaseous state."
-	prereq_ids = list("basic_shuttle")
+	prereq_ids = list("basic_shuttle", "basic_plasma")
 	design_ids = list("plasma_refiner")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
-	hidden = TRUE
 
 /////////////////////////integrated circuits tech/////////////////////////
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -4,6 +4,7 @@
 This file contains multiple changes to make technology more suited to SinguloStation Blue.
 Instead of sprinkling comments around the file, the changes are noted down here:
 
+- Ore Silo was moved from Applied Bluespace Research to Advanced Engineering
 */
 
 //Current rate: 135000 research points in 90 minutes
@@ -179,7 +180,7 @@ Instead of sprinkling comments around the file, the changes are noted down here:
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "weldingmask", "rcd_loaded", "rpd_loaded", "ranged_analyzer")
+	design_ids = list("engine_goggles", "magboots", "weldingmask", "rcd_loaded", "rpd_loaded", "ranged_analyzer", "ore_silo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -283,7 +284,7 @@ Instead of sprinkling comments around the file, the changes are noted down here:
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "ore_silo", "antivirus3")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "antivirus3")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -13,6 +13,7 @@ Instead of sprinkling comments around the file, the changes are noted down here:
  - Tech tier lowered from 4 to 2
  - Added dependency on basic_plasma
  - No longer a hidden research
+- Nullspace Breaching now depends on Bluespace Travel
 */
 
 //Current rate: 135000 research points in 90 minutes
@@ -353,7 +354,7 @@ Instead of sprinkling comments around the file, the changes are noted down here:
 	id = "nullspacebreaching"
 	display_name = "Nullspace Breaching"
 	description = "Research into voidspace tunnelling, allowing us to significantly reduce flight times."
-	prereq_ids = list("basic_shuttle", "alientech")
+	prereq_ids = list("basic_shuttle", "bluespace_travel", "alientech")
 	design_ids = list("engine_void", "wingpack_ayy")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
 	export_price = 5000

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
@@ -36,8 +36,10 @@
 /obj/item/disk/tech_disk/research/swapper
 	node_id = "qswapper"
 
+/* Singulostation edit - Technology tweaks
 /obj/item/disk/tech_disk/research/plasma_refiner
 	node_id = "plasmarefiner"
+*/
 
 /obj/item/disk/tech_disk/research/adv_combat_implants
 	node_id = "adv_combat_cyber_implants"

--- a/whitesands/code/modules/research/techweb/all_nodes.dm
+++ b/whitesands/code/modules/research/techweb/all_nodes.dm
@@ -1,10 +1,13 @@
 ////////////////////// Deepcore ///////////////////////
 
+//Singulostation begin - Technology tweaks
 /datum/techweb_node/deepcore
 	id = "deepcore"
+	tech_tier = 2
 	display_name = "Deepcore Mining"
 	description = "Mining, but automated."
-	prereq_ids = list("basic_mining")
+	prereq_ids = list("basic_mining", "adv_engi")
 	design_ids = list("deepcore_drill", "deepcore_hopper", "deepcore_hub")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 2500
+//Singulostation end


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PR:
- https://github.com/SinguloStation13/SinguloStation-Blue/pull/334

List of changes thus far:
- Ore Silo was moved from Applied Bluespace Research to Advanced Engineering
- Basic Shuttle Technology has been moved up:
  - Tech tier lowered from 3 to 1
  - Dependencies removed - can be researched roundstart
  - Cost halved from 10000 to 5000
- Plasma Refining has been moved up
  - Tech tier lowered from 4 to 2
  - Added dependency on basic_plasma
  - No longer a hidden research
- Nullspace Breaching now depends on Bluespace Travel
- Deepcore mining has been assigned a tier - 2. It also now depends on advanced engineering.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Shuttle technology being endgame on a construction-oriented server with shuttle-dependent research progression is pretty weird. Having no ore silo is mostly just a nuisance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

**This PR has not been tested.**

<details>
<summary>Screenshots&Videos</summary>

N/A

</details>

## Changelog
:cl:
balance: Tweaked the technology to make more sense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
