### PR TITLE
Adds `/singulostation` and `/whitesands` to build.js

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -69,6 +69,8 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
+    'singulostation/**',
+    'whitesands/**',
     `${DME_NAME}.dme`,
   ],
   outputs: [


### PR DESCRIPTION
This is so that when building, the build script will check `/singulostation` and `/whitesands` for changes

## Changelog
:cl:
tweak: fixes build script
/:cl:
