### PR TITLE
[Port] [Ready] Fixes ping display dying after a long time

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(server_maint)
 				continue
 
 		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
-			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
+			winset(C, null, "command=\".update_ping [world.time+world.tick_lag*TICK_USAGE_REAL/100]\"") // SinguloStation edit - Fix ping display
 
 		if (MC_TICK_CHECK) //one day, when ss13 has 1000 people per server, you guys are gonna be glad I added this tick check
 			return

--- a/code/modules/client/verbs/ping.dm
+++ b/code/modules/client/verbs/ping.dm
@@ -19,4 +19,4 @@
 /client/verb/ping()
 	set name = "Ping"
 	set category = "OOC"
-	winset(src, null, "command=.display_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
+	winset(src, null, "command=\".display_ping [world.time+world.tick_lag*TICK_USAGE_REAL/100]\"") // SinguloStation edit - Fix ping display


### PR DESCRIPTION
## Original PR: https://github.com/SinguloStation13/SinguloStation13-Archived/pull/33

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After a long time, the client will start trying to call the .update_ping verb with scientific notation server time, breaking the syntax of `winset()`.
This fix encapsulates the number into a pair of quotes so it doesn't think the + in the scientific notation is supposed to be a space.

## Why It's Good For The Game

Seeing your ping is pretty nice :)

## Changelog
:cl: Urumasi
fix: Fixes ping becoming useless after really long round durations
/:cl:
