### PR TITLE
Gives Stations Holofans So Cryo Rooms Don't Get Fucking Spaced

### DIFF
--- a/_maps/map_files/ConstructionStation/ConstructionStation.dmm
+++ b/_maps/map_files/ConstructionStation/ConstructionStation.dmm
@@ -2185,6 +2185,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/plating,
 /area/science/research)
 "TZ" = (

--- a/_maps/map_files/CryoStation/CryoStation.dmm
+++ b/_maps/map_files/CryoStation/CryoStation.dmm
@@ -886,6 +886,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/plating,
 /area/maintenance/cryoauxatmos)
 "ti" = (


### PR DESCRIPTION
Title says it all. Atmos lockers in atmos, alongside atmos gear also has 3 more holofans.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
As stated, atmos lockers for each station's atmospherics and 3 extra holofans for more construction

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
It is really bad for the room where everyone spawns to get spaced

## Testing Photographs and Procedure

github doesnt wanna process the files so just links

https://gyazo.com/8b27be5c8e4c781742c2975202343fa8
https://gyazo.com/0e095e202ff065c7706186f8987bb5a4

</details>

## Changelog
:cl:
add: Atmos lockers for the stations as a countermeasure to cryo getting spaced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
