### PR TITLE
Kills mail, also adds some atmos stuff in the hallways.

### DIFF
--- a/_maps/map_files/ConstructionStation/ConstructionStation.dmm
+++ b/_maps/map_files/ConstructionStation/ConstructionStation.dmm
@@ -387,9 +387,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ls" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
@@ -870,6 +868,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
+"uV" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/bridge)
 "vi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -981,14 +986,16 @@
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "wO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge)
 "wW" = (
@@ -1869,6 +1876,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"JX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "Ko" = (
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
@@ -2078,6 +2094,15 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"MP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "MZ" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
@@ -2400,6 +2425,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"Vm" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "Vx" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -18354,7 +18383,7 @@ Fg
 aL
 jg
 lq
-lq
+MP
 lq
 Ys
 eU
@@ -18868,7 +18897,7 @@ sa
 aM
 ls
 sh
-lP
+JX
 lP
 vU
 Aa
@@ -19126,13 +19155,13 @@ sa
 sW
 GE
 bB
-bB
+uV
 sW
 dj
 Cz
 Rk
 Ft
-bu
+Vm
 vH
 Sv
 Nd

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/initiate_docking()
 	if(getDockedId() == "supply_away") // Buy when we leave home.
 		buy()
-		create_mail()
+		//create_mail() //Singulostation - Remove mail
 	. = ..() // Fly/enter transit.
 	if(. != DOCKING_SUCCESS)
 		return
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	SSshuttle.centcom_message = msg
 	investigate_log("Shuttle contents sold for [D.account_balance - presale_points] credits. Contents: [ex.exported_atoms ? ex.exported_atoms.Join(",") + "." : "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
 
-
+/* Singulostation Start - Remove mail
 //	Generates a box of mail depending on our exports and imports.
 //	Applied in the cargo shuttle sending/arriving, by building the crate if the round is ready to introduce mail based on the economy subsystem.
 // Then, fills the mail crate with mail, by picking applicable crew who can recieve mail at the time to sending.
@@ -223,3 +223,4 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			empty_turfs += T
 
 	new /obj/structure/closet/crate/mail/economy(pick(empty_turfs))
+/* Singulostation End - Remove mail

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -223,4 +223,5 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			empty_turfs += T
 
 	new /obj/structure/closet/crate/mail/economy(pick(empty_turfs))
-/* Singulostation End - Remove mail
+Singulostation End - Remove mail
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
mail no longer spawns on the cargo shuttle.
adds a missing air alarm in the hallway so you can control the air.
adds a vent pump and scrubber in the bridge, along with a air alarm, so it can still get air in the case that the firelocks close.

## Why It's Good For The Game
mail bad.
being able to control the air is good.
bridge having its own vent pumps is good.

## Changelog
:cl:
del: kills mail
fix: added a missing air alarm in the hallway
tweak: added ventilation to the bridge
/:cl:
